### PR TITLE
#5 記事本文のスタイル調整

### DIFF
--- a/src/components/ArticleListItem.tsx
+++ b/src/components/ArticleListItem.tsx
@@ -2,9 +2,9 @@ import ArticleIcon from '@mui/icons-material/Article'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import { Button, Card, Chip, Stack, Typography } from '@mui/material'
 import { format } from 'date-fns'
-import ReactMarkdown from 'react-markdown'
 import { Article } from './Article'
 import Link from './common/Link'
+import { Markdown } from './common/Markdown'
 import { ShareButtons } from './common/ShareButtons'
 
 const DisplayTextLength = 500
@@ -47,9 +47,10 @@ export const ArticleListItem: React.FC<Props> = ({ article }: Props) => {
         <Typography variant="h2" pb={2}>
           <Link href={`/${article.slug}`}>{article.title}</Link>
         </Typography>
-        <ReactMarkdown>
-          {article.content.substr(0, DisplayTextLength) + '...'}
-        </ReactMarkdown>
+        <Markdown
+          content={article.content.substr(0, DisplayTextLength) + '...'}
+          isPreview={true}
+        />
         <Button
           variant="outlined"
           href={`/${article.slug}`}

--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -4,12 +4,9 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import { Card, Chip, Stack, Typography } from '@mui/material'
 import { Box } from '@mui/system'
 import { format } from 'date-fns'
-import ReactMarkdown from 'react-markdown'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { Tweet } from 'react-twitter-widgets'
-import rehypeRaw from 'rehype-raw'
 import { Article } from './Article'
 import Link from './common/Link'
+import { Markdown } from './common/Markdown'
 import { ShareButtons } from './common/ShareButtons'
 
 interface Props {
@@ -51,45 +48,7 @@ export const ArticlePage: React.FC<Props> = ({ article }) => {
           <Typography variant="h2" gutterBottom pb={4}>
             <Link href={article.slug}>{article.title}</Link>
           </Typography>
-          <ReactMarkdown
-            rehypePlugins={[rehypeRaw]}
-            components={{
-              a: ({ children, href, ref, ...props }) =>
-                href ? (
-                  <Link href={href ?? '/'} {...props} children={children} />
-                ) : (
-                  <a ref={ref} {...props}>
-                    {children}
-                  </a>
-                ),
-              code({ inline, className, children }) {
-                const match = /language-(\w+)/.exec(className || '')
-                if (className === 'language-twitter') {
-                  return <Tweet tweetId={String(children).replace(/\n$/, '')} />
-                }
-                return !inline ? (
-                  <SyntaxHighlighter
-                    children={String(children).replace(/\n$/, '')}
-                    language={match ? match[1] : undefined}
-                    PreTag="div"
-                  />
-                ) : (
-                  <strong style={{ color: '#777' }}>{children}</strong>
-                )
-              },
-              img({ src, alt, title }) {
-                return (
-                  <img
-                    src={src}
-                    alt={alt}
-                    title={title}
-                    style={{ maxWidth: '100%' }}
-                  />
-                )
-              },
-            }}>
-            {article.content}
-          </ReactMarkdown>
+          <Markdown content={article.content} />
           <Stack direction="row" spacing={2} pt={4}>
             <ShareButtons
               url={`https://53ningen.com/${article.slug}`}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,4 +1,5 @@
 import { Stack, Toolbar, Typography } from '@mui/material'
+import { styled } from '@mui/system'
 import { FaEdit, FaGithub, FaHome, FaIdCard, FaTwitter } from 'react-icons/fa'
 import Link from './Link'
 
@@ -6,12 +7,20 @@ const title = '53ningen.com'
 const subtitle = `@gomi_ningen's Website`
 
 export const Header: React.FC = () => {
+  const TitleLink = styled(Link)(
+    ({ theme }) => `
+    color: ${theme.palette.text.primary};
+  `
+  )
+
   return (
     <>
       <Toolbar sx={{ justifyContent: 'space-evenly' }}>
-        <Typography variant="h1" align="center" noWrap>
-          {title}
-        </Typography>
+        <TitleLink href="/" style={{ textDecoration: 'none' }}>
+          <Typography variant="h1" align="center" noWrap>
+            {title}
+          </Typography>
+        </TitleLink>
       </Toolbar>
       <Typography variant="subtitle1" align="center">
         {subtitle}

--- a/src/components/common/Link.tsx
+++ b/src/components/common/Link.tsx
@@ -82,7 +82,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         className={className}
         href={href}
         ref={ref}
-        style={{ textDecoration: 'none' }}
         target="_blank"
         {...other}
       />
@@ -102,7 +101,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       className={className}
       ref={ref}
       to={href}
-      style={{ textDecoration: 'none' }}
       {...other}
     />
   )

--- a/src/components/common/Markdown.tsx
+++ b/src/components/common/Markdown.tsx
@@ -1,0 +1,102 @@
+import { Typography } from '@mui/material'
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { Tweet } from 'react-twitter-widgets'
+import rehypeRaw from 'rehype-raw'
+import Link from './Link'
+
+interface Props {
+  content: string
+  isPreview?: boolean
+}
+
+export const Markdown: React.FC<Props> = ({ content, isPreview }) => {
+  return (
+    <ReactMarkdown
+      rehypePlugins={isPreview ? [] : [rehypeRaw]}
+      components={{
+        a: ({ children, href, ref, ...props }) =>
+          href ? (
+            <Link href={href ?? '/'} {...props} children={children} />
+          ) : (
+            <a ref={ref} {...props}>
+              {children}
+            </a>
+          ),
+        code({ inline, className, children }) {
+          const match = /language-(\w+)/.exec(className || '')
+          if (className === 'language-twitter') {
+            return <Tweet tweetId={String(children).replace(/\n$/, '')} />
+          }
+          return !inline ? (
+            <SyntaxHighlighter
+              children={String(children).replace(/\n$/, '')}
+              language={match ? match[1] : undefined}
+              PreTag="div"
+            />
+          ) : (
+            <strong style={{ color: '#777' }}>{children}</strong>
+          )
+        },
+        img({ src, alt, title }) {
+          return (
+            <img
+              src={src}
+              alt={alt}
+              title={title}
+              style={{ maxWidth: '100%' }}
+            />
+          )
+        },
+        ul: ({ children, depth, ...props }) =>
+          depth === 0 ? (
+            <ul {...props} style={{ paddingLeft: '1em' }}>
+              {children}
+            </ul>
+          ) : (
+            <ul {...props} style={{ paddingLeft: 0, marginLeft: '1em' }}>
+              {children}
+            </ul>
+          ),
+        li: ({ children }) => (
+          <li style={{ textAlign: 'justify' }}>{children}</li>
+        ),
+        h1: ({ children }) => (
+          <Typography variant="h1" pt={6}>
+            {children}
+          </Typography>
+        ),
+        h2: ({ children }) => (
+          <Typography variant="h2" pt={6}>
+            {children}
+          </Typography>
+        ),
+        h3: ({ children }) => (
+          <Typography variant="h3" pt={4}>
+            {children}
+          </Typography>
+        ),
+        h4: ({ children }) => (
+          <Typography variant="h4" pt={2}>
+            {children}
+          </Typography>
+        ),
+        h5: ({ children }) => (
+          <Typography variant="h5" pt={2}>
+            {children}
+          </Typography>
+        ),
+        h6: ({ children }) => (
+          <Typography variant="h6" pt={2}>
+            {children}
+          </Typography>
+        ),
+        p: ({ children }) => (
+          <Typography textAlign="justify">{children}</Typography>
+        ),
+      }}>
+      {content}
+    </ReactMarkdown>
+  )
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,6 +3,9 @@ import { createTheme } from '@mui/material/styles'
 
 const theme = createTheme({
   palette: {
+    text: {
+      primary: '#333',
+    },
     primary: {
       main: '#556cd6',
     },
@@ -32,8 +35,15 @@ const theme = createTheme({
   },
   components: {
     MuiLink: {
-      styleOverrides: {
-        underlineAlways: 'none',
+      defaultProps: {
+        underline: 'hover',
+      },
+    },
+    MuiChip: {
+      defaultProps: {
+        style: {
+          cursor: 'pointer',
+        },
       },
     },
   },


### PR DESCRIPTION
#5 + α の対応

* リストインデント調整
* 見出し上部間隔調整
* サイト名にトップページへのリンクを張った
* 記事本文テキスト両端揃え
* 本文テキストカラーを 333 に変更
* チップ hover 時に pointer となるよう変更
* リンク hover 時に下線を出す