### PR TITLE
記事本文中 blockquote へのスタイルを設定

### DIFF
--- a/pages/styles.css
+++ b/pages/styles.css
@@ -2,3 +2,11 @@ body {
   font-family: 'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica',
     'Arial', sans-serif;
 }
+
+blockquote {
+  position: relative;
+  padding: 1em;
+  font-size: 0.75em;
+  color: #666;
+  border-left: 5px solid #ccc;
+}


### PR DESCRIPTION
### before

<img width="828" alt="スクリーンショット 2021-12-18 20 00 23" src="https://user-images.githubusercontent.com/4178716/146638659-2974d889-5977-4858-a5eb-3a445ab45a33.png">



### after

<img width="884" alt="スクリーンショット 2021-12-18 20 00 10" src="https://user-images.githubusercontent.com/4178716/146638662-9fee652b-5fea-4728-b379-d2008d8a041f.png">
